### PR TITLE
Add SkiaSharp native assets

### DIFF
--- a/OpenXmlPowerTools.Tests/ColorParserTests.cs
+++ b/OpenXmlPowerTools.Tests/ColorParserTests.cs
@@ -8,13 +8,49 @@ namespace Codeuctivity.Tests
     {
         [Theory]
         [InlineData("red", 255, 0, 0)]
+        [InlineData("RED", 255, 0, 0)]
         [InlineData("#00FF00", 0, 255, 0)]
+        [InlineData("#00ff00", 0, 255, 0)]
+        [InlineData("blue", 0, 0, 255)]
+        [InlineData("#0000FF", 0, 0, 255)]
+        [InlineData("#abc", 170, 187, 204)]
+        [InlineData("yellow", 255, 255, 0)]
+        [InlineData("black", 0, 0, 0)]
+        [InlineData("white", 255, 255, 255)]
         public void ShouldParseColors(string input, byte r, byte g, byte b)
         {
             var result = ColorParser.FromName(input);
             Assert.Equal(r, result.Red);
             Assert.Equal(g, result.Green);
             Assert.Equal(b, result.Blue);
+        }
+
+        [Theory]
+        [InlineData("red", true)]
+        [InlineData("#123456", true)]
+        [InlineData("notacolor", false)]
+        [InlineData("", false)]
+        public void ShouldValidateColorNames(string input, bool valid)
+        {
+            Assert.Equal(valid, ColorParser.IsValidName(input));
+        }
+
+        [Fact]
+        public void FromNameShouldThrowOnInvalid()
+        {
+            Assert.Throws<System.ArgumentException>(() => ColorParser.FromName("bogus"));
+        }
+
+        [Theory]
+        [InlineData("notacolor")]
+        [InlineData("#GGGGGG")]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("   ")]
+        public void ShouldRejectInvalidColors(string? input)
+        {
+            var success = ColorParser.TryFromName(input, out SKColor _);
+            Assert.False(success);
         }
     }
 }

--- a/OpenXmlPowerTools.Tests/CssPropertyValueTests.cs
+++ b/OpenXmlPowerTools.Tests/CssPropertyValueTests.cs
@@ -1,0 +1,45 @@
+using Codeuctivity.OpenXmlPowerTools;
+using SkiaSharp;
+using Xunit;
+
+namespace Codeuctivity.Tests
+{
+    public class CssPropertyValueTests
+    {
+        [Fact]
+        public void ShouldRecognizeNamedColor()
+        {
+            var value = new CssPropertyValue { Type = CssValueType.String, Value = "red" };
+            Assert.True(value.IsColor);
+            var color = value.ToColor();
+            Assert.Equal(SKColors.Red, color);
+        }
+
+        [Fact]
+        public void ShouldRecognizeHexColor()
+        {
+            var value = new CssPropertyValue { Type = CssValueType.Hex, Value = "#0000FF" };
+            Assert.True(value.IsColor);
+            var color = value.ToColor();
+            Assert.Equal(SKColors.Blue, color);
+        }
+
+        [Fact]
+        public void ShouldRejectNonColor()
+        {
+            var value = new CssPropertyValue { Type = CssValueType.String, Value = "1234" };
+            Assert.False(value.IsColor);
+        }
+
+        [Fact]
+        public void ShouldParseHexWithoutHash()
+        {
+            var value = new CssPropertyValue { Type = CssValueType.Hex, Value = "00FF00" };
+            Assert.True(value.IsColor);
+            var color = value.ToColor();
+            Assert.Equal(0u, color.Red);
+            Assert.Equal(255u, color.Green);
+            Assert.Equal(0u, color.Blue);
+        }
+    }
+}

--- a/OpenXmlPowerTools.Tests/ImageHandlerTests.cs
+++ b/OpenXmlPowerTools.Tests/ImageHandlerTests.cs
@@ -1,0 +1,93 @@
+using System.IO;
+using System.Xml.Linq;
+using Codeuctivity.OpenXmlPowerTools;
+using Codeuctivity.OpenXmlPowerTools.OpenXMLWordprocessingMLToHtmlConverter;
+using SkiaSharp;
+using Xunit;
+
+namespace Codeuctivity.Tests
+{
+    public class ImageHandlerTests
+    {
+        [Theory]
+        [InlineData(SKEncodedImageFormat.Png, "image/png")]
+        [InlineData(SKEncodedImageFormat.Jpeg, "image/jpeg")]
+        [InlineData(SKEncodedImageFormat.Webp, "image/webp")]
+        public void ShouldTransformImagesToDataUri(SKEncodedImageFormat format, string mime)
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(10, 10));
+            surface.Canvas.Clear(SKColors.Red);
+            using var image = surface.Snapshot();
+            using var ms = new MemoryStream();
+            using (var data = image.Encode(format, 100))
+            {
+                data.SaveTo(ms);
+            }
+            ms.Position = 0;
+            var info = new ImageInfo { Image = ms, AltText = "alt", ImgStyleAttribute = new XAttribute(NoNamespace.style, "width:10px") };
+            var handler = new ImageHandler();
+            var result = handler.TransformImage(info);
+            var srcAttr = result.Attribute(NoNamespace.src);
+            Assert.NotNull(srcAttr);
+            Assert.StartsWith($"data:{mime};base64,", srcAttr.Value);
+            Assert.Equal("width:10px", result.Attribute(NoNamespace.style)?.Value);
+        }
+
+        [Fact]
+        public void ShouldTransformGifToDataUri()
+        {
+            var gif = System.Convert.FromBase64String("R0lGODlhAQABAPAAAP///wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==");
+            using var ms = new MemoryStream(gif);
+            var info = new ImageInfo { Image = ms };
+            var handler = new ImageHandler();
+            var result = handler.TransformImage(info);
+            var srcAttr = result.Attribute(NoNamespace.src);
+            Assert.NotNull(srcAttr);
+            Assert.StartsWith("data:image/gif;base64,", srcAttr.Value);
+        }
+
+        [Fact]
+        public void ShouldThrowOnInvalidImage()
+        {
+            using var ms = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+            var handler = new ImageHandler();
+            Assert.ThrowsAny<System.Exception>(() => handler.TransformImage(new ImageInfo { Image = ms }));
+        }
+
+        [Fact]
+        public void ShouldIncludeAltText()
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(5, 5));
+            surface.Canvas.Clear(SKColors.Blue);
+            using var image = surface.Snapshot();
+            using var ms = new MemoryStream();
+            using (var data = image.Encode(SKEncodedImageFormat.Png, 100))
+            {
+                data.SaveTo(ms);
+            }
+            ms.Position = 0;
+            var info = new ImageInfo { Image = ms, AltText = "demo" };
+            var handler = new ImageHandler();
+            var result = handler.TransformImage(info);
+            Assert.Equal("demo", result.Attribute(NoNamespace.alt)?.Value);
+        }
+
+        [Fact]
+        public void ShouldOmitAltTextWhenNotProvided()
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(5, 5));
+            surface.Canvas.Clear(SKColors.Blue);
+            using var image = surface.Snapshot();
+            using var ms = new MemoryStream();
+            using (var data = image.Encode(SKEncodedImageFormat.Png, 100))
+            {
+                data.SaveTo(ms);
+            }
+            ms.Position = 0;
+            var info = new ImageInfo { Image = ms };
+            var handler = new ImageHandler();
+            var result = handler.TransformImage(info);
+            Assert.Null(result.Attribute(NoNamespace.alt));
+        }
+    }
+}

--- a/OpenXmlPowerTools.Tests/OpenXmlPowerTools.Tests.csproj
+++ b/OpenXmlPowerTools.Tests/OpenXmlPowerTools.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Codeuctivity.HtmlRenderer" Version="4.0.438" />
     <PackageReference Include="Codeuctivity.SkiaSharpCompare" Version="3.0.165-PreRelease" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/OpenXmlPowerTools/OpenXmlPowerTools.csproj
+++ b/OpenXmlPowerTools/OpenXmlPowerTools.csproj
@@ -42,14 +42,15 @@
 		<None Remove="Properties\**" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+                <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
                 <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
                 <PackageReference Include="SkiaSharp" Version="3.119.0" />
-		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.7.0.110445">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+                <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.0" />
+                <PackageReference Include="SonarAnalyzer.CSharp" Version="10.7.0.110445">
+                        <PrivateAssets>all</PrivateAssets>
+                        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                </PackageReference>
+        </ItemGroup>
 	<ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
 		<PackageReference Include="System.IO.Packaging" Version="9.0.1" />
 		<PackageReference Include="System.IO.Compression" Version="4.3.0" />

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ File.WriteAllText("./target.html", htmlString, Encoding.UTF8);
   enables writing XLSX files with millions of rows.
 - Extracting data (along with formatting) from spreadsheets.
 
+## SkiaSharp migration
+
+Earlier releases used the ImageSharp library for tasks such as decoding images in the WordprocessingML to HTML converter and validating rendering output in tests. ImageSharp's powerful API came with a more restrictive licensing model that could require commercial agreements, which proved limiting for downstream projects.
+
+The project now uses SkiaSharp to handle these responsibilities. SkiaSharp, distributed under the permissive MIT license, provides cross-platform bindings to the Skia graphics engine. By leveraging SkiaSharp's `SKCodec` and `SKImage` APIs for image transformation and `SKColor` for color parsing, the codebase avoids licensing friction while retaining rich imaging capabilities.
+
 ## Development
 
 - Run `dotnet build OpenXmlPowerTools.sln`


### PR DESCRIPTION
## Summary
- ensure SkiaSharp native assets are bundled for library and tests
- add comprehensive tests validating SkiaSharp image handling, color parsing, and CSS color value support
- document migration from ImageSharp to SkiaSharp and its licensing benefits

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689f022e43f483258b8137ec34efaa4a